### PR TITLE
12 fix subvol for cell volume seeding

### DIFF
--- a/projects/AVISO/namelist_AVISO.in
+++ b/projects/AVISO/namelist_AVISO.in
@@ -75,6 +75,8 @@
 
      timeformat    = 0            ! Format of the time array
                                   ! 0 - tt / 1 - ts / 2 - YYYY, MM, DD, HH
+
+     l_compress = .FALSE.,        ! Compress _run.csv files on exceeding 2GB filesize using gzip
 /
 
 &INIT_SEEDING
@@ -93,10 +95,11 @@
      														   ! = 3 Each particle reflects air/water mass/volume at seeding.
      														   !     set by partQuant in m3 or kg per particle
 
+      nsdtraj        = 10,         ! number of trajectories to allocate per seeding cell (used for allocation if nqua > 1)
       partquant      = 10,         ! particles/gridcell or m3s-1/particle or m3/particle
-      loneparticle   = 0, 				 ! start only one trajectory for debugging
-      seedtype       = 1,				   ! = 1 seed using ist,jst,kst (below)
-          		      					     ! = 2 seed using file with start positions
+      loneparticle   = 0, 	     ! start only one trajectory for debugging
+      seedtype       = 1,	     ! = 1 seed using ist,jst,kst (below)
+          		      	     ! = 2 seed using file with start positions
 
      	! when seedtype = 1
       ist1           = 135,				    ! seed in box in range i = [ist1,ist2]
@@ -163,5 +166,7 @@
 /
 
 &INIT_ACTIVE
-
+      l_diffusion = .FALSE.         ! Apply Stochastic diffusion along particle trajectories
+      Ah = 0                        ! Horizontal diffusivity coefficient
+      Av = 0                        ! Vertical diffusivity coefficient
 /

--- a/projects/IFS/namelist_IFS.in
+++ b/projects/IFS/namelist_IFS.in
@@ -78,8 +78,10 @@
      outDataDir    = '',
      outDataFile   = '',
 
-     timeformat    = 0     ! Format of the time array
-                           ! 0 - tt / 1 - ts / 2 - YYYY, MM, DD, HH
+     timeformat    = 0          ! Format of the time array
+                                ! 0 - tt / 1 - ts / 2 - YYYY, MM, DD, HH
+
+     l_compress = .FALSE.,      ! Compress _run.csv files on exceeding 2GB filesize using gzip
 /
 
 &INIT_SEEDING
@@ -98,10 +100,11 @@
      														   ! = 3 Each particle reflects air/water mass/volume at seeding.
      														   !     set by partQuant in m3 or kg per particle
 
+      nsdtraj        = 10,         ! number of trajectories to allocate per seeding cell (used for allocation if nqua > 1)
       partquant      = 1,          ! particles/gridcell or m3s-1/particle or m3/particle
-      loneparticle   = 0, 				 ! start only one trajectory for debugging
-      seedtype       = 1,				   ! = 1 seed using ist,jst,kst (below)
-          		      					     ! = 2 seed using file with start positions
+      loneparticle   = 0, 	     ! start only one trajectory for debugging
+      seedtype       = 1,	     ! = 1 seed using ist,jst,kst (below)
+          		      	     ! = 2 seed using file with start positions
 
      	! when seedtype = 1
       ist1           = 70,				    ! seed in box in range i = [ist1,ist2]
@@ -196,5 +199,7 @@
 /
 
 &INIT_ACTIVE
-
+      l_diffusion = .FALSE.         ! Apply Stochastic diffusion along particle trajectories
+      Ah = 0                        ! Horizontal diffusivity coefficient
+      Av = 0                        ! Vertical diffusivity coefficient
 /

--- a/projects/NEMO/namelist_ORCA1.in
+++ b/projects/NEMO/namelist_ORCA1.in
@@ -102,30 +102,33 @@
      outDataDir    = '',
      outDataFile   = '',
 
-     timeformat    = 0     ! Format of the time array
-                           ! 0 - tt / 1 - ts / 2 - YYYY, MM, DD, HH
+     timeformat    = 0       ! Format of the time array
+                             ! 0 - tt / 1 - ts / 2 - YYYY, MM, DD, HH
+
+     l_compress = .FALSE.,   ! Compress _run.csv files on exceeding 2GB filesize using gzip
 /
 
 &INIT_SEEDING
       nff            = 1,          ! = 1 run forward trajectories
-          		      					     ! = -1 run backwards
-      isec           = 2,				   ! = 1 start on zonal cell wall
-          		      					     ! = 2 start on meridional cell wall
-     							                 ! = 3 start on vertical wall
-      idir           = -1, 				 ! = 1 start only when flux > 0
-          		      					     ! = -1      only when flux < 0
-     	nqua           = 1,					 ! number of trajectories can be set by
-     														   ! = 1 constant number of particles in all seeding cells
-     														   !     set by partQuant (particles / gridcell)
-     														   ! = 2 Each particle reflects mass transport at seeding.
-     														   !     set by partQuant (m3/s or kg/s per particle)
-     														   ! = 3 Each particle reflects air/water mass/volume at seeding.
-     														   !     set by partQuant in m3 or kg per particle
+          		      	     ! = -1 run backwards
+      isec           = 2,	     ! = 1 start on zonal cell wall
+          		      	     ! = 2 start on meridional cell wall
+     					     ! = 3 start on vertical wall
+      idir           = -1, 	     ! = 1 start only when flux > 0
+          		      	     ! = -1      only when flux < 0
+     	nqua           = 1,	     ! number of trajectories can be set by
+     							! = 1 constant number of particles in all seeding cells
+     							!     set by partQuant (particles / gridcell)
+     							! = 2 Each particle reflects mass transport at seeding.
+     							!     set by partQuant (m3/s or kg/s per particle)
+     							! = 3 Each particle reflects air/water mass/volume at seeding.
+     							!     set by partQuant in m3 or kg per particle
 
+      nsdtraj        = 10,         ! number of trajectories to allocate per seeding cell (used for allocation if nqua > 1)
       partquant      = 1,          ! particles/gridcell or m3s-1/particle or m3/particle
-      loneparticle   = 0, 				 ! start only one trajectory for debugging
-      seedtype       = 1,				   ! = 1 seed using ist,jst,kst (below)
-          		      					     ! = 2 seed using file with start positions
+      loneparticle   = 0, 	     ! start only one trajectory for debugging
+      seedtype       = 1,	     ! = 1 seed using ist,jst,kst (below)
+          		      	     ! = 2 seed using file with start positions
 
      	! when seedtype = 1
       ist1           = 220, 				    ! seed in box in range i = [ist1,ist2]
@@ -216,5 +219,7 @@
 /
 
 &INIT_ACTIVE
-
+      l_diffusion = .FALSE.         ! Apply Stochastic diffusion along particle trajectories
+      Ah = 0                        ! Horizontal diffusivity coefficient
+      Av = 0                        ! Vertical diffusivity coefficient
 /

--- a/projects/ROMS/namelist_ROMS.in
+++ b/projects/ROMS/namelist_ROMS.in
@@ -103,8 +103,10 @@
      outDataDir    = '',
      outDataFile   = '',
 
-     timeformat    = 0     ! Format of the time array
-                           ! 0 - tt / 1 - ts / 2 - YYYY, MM, DD, HH
+     timeformat    = 0       ! Format of the time array
+                             ! 0 - tt / 1 - ts / 2 - YYYY, MM, DD, HH
+
+     l_compress = .FALSE.,   ! Compress _run.csv files on exceeding 2GB filesize using gzip
 /
 
 &INIT_SEEDING
@@ -123,10 +125,11 @@
      														   ! = 3 Each particle reflects air/water mass/volume at seeding.
      														   !     set by partQuant in m3 or kg per particle
 
+      nsdtraj        = 10,         ! number of trajectories to allocate per seeding cell (used for allocation if nqua > 1)
       partquant      = 1,          ! particles/gridcell or m3s-1/particle or m3/particle
-      loneparticle   = 0, 				 ! start only one trajectory for debugging
-      seedtype       = 1,				   ! = 1 seed using ist,jst,kst (below)
-          		      					     ! = 2 seed using file with start positions
+      loneparticle   = 0,          ! start only one trajectory for debugging
+      seedtype       = 1,          ! = 1 seed using ist,jst,kst (below)
+          		      	     ! = 2 seed using file with start positions
 
      	! when seedtype = 1
       ist1           = 65, 				    ! seed in box in range i = [ist1,ist2]
@@ -218,5 +221,7 @@
 /
 
 &INIT_ACTIVE
-
+      l_diffusion = .FALSE.         ! Apply Stochastic diffusion along particle trajectories
+      Ah = 0                        ! Horizontal diffusivity coefficient
+      Av = 0                        ! Vertical diffusivity coefficient
 /

--- a/projects/Theoretical/namelist_Theoretical.in
+++ b/projects/Theoretical/namelist_Theoretical.in
@@ -67,29 +67,33 @@
 
      timeformat    = 1                     ! Format of the time array
                                            ! 0 - tt / 1 - ts / 2 - YYYY, MM, DD, HH
+
+
+     l_compress = .FALSE.,                 ! Compress _run.csv files on exceeding 2GB filesize using gzip
 /
 
 &INIT_SEEDING
-      nff            = 1,                  ! = 1 run forward trajectories
-          		      					             ! = -1 run backwards
-      isec           = 1,				           ! = 1 start on zonal cell wall
-          		      					             ! = 2 start on meridional cell wall
-     							                         ! = 3 start on vertical wall
-      idir           = 1,				           ! = 1 start only when flux > 0
-          		      					             ! = -1      only when flux < 0
-     	nqua           = 1,									 ! number of trajectories can be set by
-     														           ! = 1 constant number of particles in all seeding cells
-     														           !     set by partQuant (particles / gridcell)
-     														           ! = 2 Each particle reflects mass transport at seeding.
-     														           !     set by partQuant (m3/s or kg/s per particle)
-     														           ! = 3 Each particle reflects air/water mass/volume at seeding.
-     														           !     set by partQuant in m3 or kg per particle
+      nff            = 1,               ! = 1 run forward trajectories
+          		      			! = -1 run backwards
+      isec           = 1,			! = 1 start on zonal cell wall
+          		      			! = 2 start on meridional cell wall
+     							! = 3 start on vertical wall
+      idir           = 1,			! = 1 start only when flux > 0
+          		      			! = -1      only when flux < 0
+      nqua           = 1,			! number of trajectories can be set by
+     							! = 1 constant number of particles in all seeding cells
+     							!     set by partQuant (particles / gridcell)
+     							! = 2 Each particle reflects mass transport at seeding.
+     							!     set by partQuant (m3/s or kg/s per particle)
+     							! = 3 Each particle reflects air/water mass/volume at seeding.
+     							!     set by partQuant in m3 or kg per particle
 
-      partquant      = 1,                  ! particles/gridcell or m3s-1/particle or m3/particle
-      loneparticle   = 0, 				         ! start only one trajectory for debugging
+      nsdtraj        = 10,         ! number of trajectories to allocate per seeding cell (used for allocation if nqua > 1)
+      partquant      = 1,          ! particles/gridcell or m3s-1/particle or m3/particle
+      loneparticle   = 0, 		! start only one trajectory for debugging
 
-      seedtype       = 1,				           ! = 1 seed using ist,jst,kst (below)
-          		      					             ! = 2 seed using file with start positions
+      seedtype       = 1,		! = 1 seed using ist,jst,kst (below)
+          		      		! = 2 seed using file with start positions
 
       ! when seedtype = 1
       ist1           = 150,				         ! seed in box in range i = [ist1,ist2]

--- a/src/_funit/mod_seed.fun
+++ b/src/_funit/mod_seed.fun
@@ -348,6 +348,7 @@ TEST test_seed_7
    !partQuant
    partQuant = 10
    nqua = 2
+   nsdtraj = 10
 
    CALL init_seed
    CALL seed
@@ -376,6 +377,7 @@ TEST test_seed_8
    !partQuant
    partQuant = 1
    nqua = 2
+   nsdtraj = 10
 
    CALL init_seed
    CALL seed

--- a/src/mod_init.F90
+++ b/src/mod_init.F90
@@ -57,13 +57,13 @@ MODULE mod_init
           namelist /INIT_RUN_TIME/         loopYears, loopStartYear, loopEndYear, &
                                            log_level, intrun
           namelist /INIT_WRITE_TRAJ/       write_frec, write_form, outDataDir, outDataFile, timeformat, l_compress
-          namelist /INIT_SEEDING/          nff, isec, idir, nqua, partQuant,             &
+          namelist /INIT_SEEDING/          nff, isec, idir, nqua, partQuant, nsdtraj, &
                                            loneparticle, SeedType, ist1,  &
-                                           ist2, jst1, jst2, kst1, kst2, tst1, tst2,&
+                                           ist2, jst1, jst2, kst1, kst2, tst1, tst2, &
                                            seedDir, seedFile, maskFile, seedTime, timeFile
           namelist /INIT_TRACERS/          l_tracers, l_swtraj, tracertrajscale, &
                                            tracername, tracershift, tracerscale, &
-                                           tracerunit, tracervarname,&
+                                           tracerunit, tracervarname, &
                                            traceraction,tracermin, tracermax, &
                                            tracerdimension
           namelist /INIT_TRACERS_SEEDING/  tracer0min, tracer0max

--- a/src/mod_seed.F90
+++ b/src/mod_seed.F90
@@ -408,7 +408,7 @@ MODULE mod_seed
                       END IF
 
                   CASE (3) ! particle reflects air/water volume at seeding
-                      vol = dxdy(ib,jb) * dzt(ib,jb,kb,nsm) * zstot(ib,jb,0)
+                      vol = dxdy(ib,jb) * dzt(ib,jb,kb,nsp) * zstot(ib,jb,0)
                       num = INT(vol/partQuant)
                   END SELECT
 

--- a/src/mod_seed.F90
+++ b/src/mod_seed.F90
@@ -272,7 +272,8 @@ MODULE mod_seed
             IF (nqua == 1) THEN
                 ntracmax = nsdMax*nsdTim*INT(partQuant)
             ELSE
-                ntracmax = nsdMax*nsdTim*10000
+                ! Allocate trajectories using nsdtraj trajectories per seed cell.
+                ntracmax = nsdMax*nsdTim*nsdtraj
             END IF
 
             ALLOCATE ( trajectories(ntracmax) )
@@ -406,8 +407,8 @@ MODULE mod_seed
                           num = (INT(SQRT(FLOAT(num))) + 1)**2
                       END IF
 
-                  CASE (3) ! particle reflects air/water mass/volume at seeding
-                      vol = dzt(ib,jb,kb,1)
+                  CASE (3) ! particle reflects air/water volume at seeding
+                      vol = dxdy(ib,jb) * dzt(ib,jb,kb,nsm) * zstot(ib,jb,0)
                       num = INT(vol/partQuant)
                   END SELECT
 

--- a/src/mod_vars.F90
+++ b/src/mod_vars.F90
@@ -80,6 +80,7 @@ MODULE mod_seedvars
 
   REAL(DP)                                   :: partQuant    ! number of particles per grid to seed
 
+  INTEGER                                    :: nsdtraj      ! number of trajectories per seed cell
   INTEGER                                    :: ist1, ist2   ! Zonal seeding region
   INTEGER                                    :: jst1, jst2   ! Meridional seeding region
   INTEGER                                    :: kst1, kst2   ! Vertical seeding region


### PR DESCRIPTION
## **Pull Request Notes**
### Summary
- Resolves #12
- Allow users to specify trajectory allocation during seeding with `nsdtraj`.
- Update example AVISO, IFS, NEMO, ROMS & Theoretical namelists.

### Details

- Updated volume definition to `vol = dxdy(ib,jb) * dzt(ib,jb,kb,nsm) * zstot(ib,jb,0)` when `nqua=3` so particles reflect fraction of total grid cell volume at seeding time.

- Update `ntracmax` definition in `mod_seed.F90` when `nqua != 0` to `ntracmax = nsdMax*nsdTim*nsdtraj` where `nsdtraj` is a user specified parameter in the namelist file in the `&INIT_SEEDING` section.

- Add existing `l_compress` option to the namelist, enabling compression of large `_run.csv` output files which exceed 2 GB  using gzip.

Additions have been tested with the Theoretical and NEMO example cases on the JASMIN HPC, UK.