### PR TITLE
Fix out-of-bounds psi_rr write in stream computation

### DIFF
--- a/src/mod_stream.F90
+++ b/src/mod_stream.F90
@@ -115,7 +115,8 @@ MODULE mod_stream
                     END DO
 
                     ! Tracer+tracer Streamfunctions
-                    IF (l_tracers) psi_rr(:,ilvar2) = psi_rr(:,ilvar2-1) - fluxes_rr(:,ilvar2,ilvar3)
+                    IF (ilvar2<=resolution .AND. l_tracers) &
+                        psi_rr(:,ilvar2) = psi_rr(:,ilvar2-1) - fluxes_rr(:,ilvar2,ilvar3)
 
                 END DO
             ELSE IF (dirpsi(ilvar1) == -1) THEN
@@ -136,7 +137,8 @@ MODULE mod_stream
                     END DO
 
                     ! Tracer+tracer Streamfunctions
-                    IF (l_tracers) psi_rr(:,ilvar2) = psi_rr(:,ilvar2+1) + fluxes_rr(:,ilvar2,ilvar3)
+                    IF (ilvar2<=resolution-1 .AND. l_tracers) &
+                        psi_rr(:,ilvar2) = psi_rr(:,ilvar2+1) + fluxes_rr(:,ilvar2,ilvar3)
 
                 END DO
             END IF


### PR DESCRIPTION
## Problem

The streamfunction accumulation loops in `compute_stream` (`src/mod_stream.F90`) run `ilvar2` up to `MAX(imtdom,jmtdom,km,resolution)`, but `psi_rr` is dimensioned `(:,resolution)`.

Unlike every other `psi_*` write in these loops (`psi_xy`, `psi_xz`, `psi_yz`, `psi_xr`, `psi_yr`), which all carry an `ilvar2<=...` bounds guard, the two `psi_rr` writes had no guard. As a result they access `psi_rr` out of bounds whenever a geographic dimension (`imtdom`/`jmtdom`/`km`) exceeds `resolution` (default 501), causing segfaults. This reproduces reliably for any domain dimension > 501.

## Fix

Add the matching bounds guards, consistent with the neighbouring `psi_xr`/`psi_yr` writes:
- forward (`dirpsi == 1`): `ilvar2<=resolution`
- reverse (`dirpsi == -1`): `ilvar2<=resolution-1`

No behavioural change when all geographic dimensions are <= `resolution`; it only suppresses the out-of-bounds writes that previously occurred past the end of `psi_rr`.