### PR TITLE
Fix _rerun.csv file handling so rerun can re-read its labels

### DIFF
--- a/projects/AVISO/kill_zones.F90
+++ b/projects/AVISO/kill_zones.F90
@@ -29,7 +29,7 @@ SUBROUTINE kill_zones
   ! Exit domain defined by the boxes [ienw, iene]x[jens, jenn]
   ! in the namelist
   CASE(1)
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1
@@ -66,7 +66,7 @@ SUBROUTINE kill_zones
       END DO
 
       ! Next the geographical killing zone
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1 + numexit

--- a/projects/IFS/kill_zones.F90
+++ b/projects/IFS/kill_zones.F90
@@ -29,7 +29,7 @@ SUBROUTINE kill_zones
   ! Exit domain defined by the boxes [ienw, iene]x[jens, jenn]
   ! in the namelist
   CASE(1)
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1
@@ -66,7 +66,7 @@ SUBROUTINE kill_zones
       END DO
 
       ! Next the geographical killing zone
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1 + numexit

--- a/projects/NEMO/kill_zones.F90
+++ b/projects/NEMO/kill_zones.F90
@@ -29,7 +29,7 @@ SUBROUTINE kill_zones
   ! Exit domain defined by the boxes [ienw, iene]x[jens, jenn]
   ! in the namelist
   CASE(1)
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1
@@ -66,7 +66,7 @@ SUBROUTINE kill_zones
       END DO
 
       ! Next the geographical killing zone
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1 + numexit

--- a/projects/ROMS/kill_zones.F90
+++ b/projects/ROMS/kill_zones.F90
@@ -29,7 +29,7 @@ SUBROUTINE kill_zones
   ! Exit domain defined by the boxes [ienw, iene]x[jens, jenn]
   ! in the namelist
   CASE(1)
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1
@@ -66,7 +66,7 @@ SUBROUTINE kill_zones
       END DO
 
       ! Next the geographical killing zone
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1 + numexit

--- a/projects/Theoretical/kill_zones.F90
+++ b/projects/Theoretical/kill_zones.F90
@@ -29,7 +29,7 @@ SUBROUTINE kill_zones
   ! Exit domain defined by the boxes [ienw, iene]x[jens, jenn]
   ! in the namelist
   CASE(1)
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1
@@ -66,7 +66,7 @@ SUBROUTINE kill_zones
       END DO
 
       ! Next the geographical killing zone
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1 + numexit

--- a/src/mod_diffusion.F90
+++ b/src/mod_diffusion.F90
@@ -191,7 +191,7 @@ MODULE mod_diffusion
         REAL(DP), INTENT(INOUT) :: xb, xa, yb, ya
         INTEGER :: nexit
 
-        DO nexit = 1, 10
+        DO nexit = 1, SIZE(ienw)
 
             ! Latitude band
             IF (jens(nexit) == jenn(nexit)) THEN

--- a/src/mod_init.F90
+++ b/src/mod_init.F90
@@ -94,6 +94,11 @@ MODULE mod_init
           READ (8,nml=INIT_ACTIVE)
           CLOSE(8)
 
+          ! Default the output-file prefix here, before it is first used.
+          ! read_rerun runs before open_outfiles, so applying the default only
+          ! inside open_outfiles left read_rerun looking for the wrong filename.
+          IF (TRIM(outDataFile) == '') outDataFile = 'TRACMASS'
+
           ! Detect the highest occupied geographic killing-zone slot from the
           ! namelist, before reverse()/zeroindx mutate the arrays below. Boxes
           ! live in up to 10 slots [ienw,iene]x[jens,jenn]; kill_zones sets

--- a/src/mod_init.F90
+++ b/src/mod_init.F90
@@ -73,6 +73,9 @@ MODULE mod_init
                                            l_divergence, divconst
           namelist /INIT_ACTIVE/           l_diffusion, ah, av
 
+          ! Loop index for scanning geographic killing-zone slots
+          INTEGER :: izone
+
           ! Read namelist
           OPEN (8,file='namelist.in',    &
                & status='OLD', delim='APOSTROPHE')
@@ -90,6 +93,19 @@ MODULE mod_init
           READ (8,nml=INIT_POSTPROCESS)
           READ (8,nml=INIT_ACTIVE)
           CLOSE(8)
+
+          ! Detect the highest occupied geographic killing-zone slot from the
+          ! namelist, before reverse()/zeroindx mutate the arrays below. Boxes
+          ! live in up to 10 slots [ienw,iene]x[jens,jenn]; kill_zones sets
+          ! nend = slot+1, so the slot INDEX (not the count) sets the largest
+          ! geographic lbas. Undefined slots are all-zero (initialised in
+          ! mod_vars). Subdomain wall zones and the final maxlbas are added in
+          ! init_subdomain, once exitType and all killing zones are finalised.
+          ngeozones = 0
+          DO izone = 1, SIZE(ienw)
+              IF (ienw(izone) /= 0 .OR. iene(izone) /= 0 .OR. &
+                  jens(izone) /= 0 .OR. jenn(izone) /= 0) ngeozones = izone
+          END DO
 
           ! If input data is on a A grid
 #ifdef A_grid
@@ -174,7 +190,7 @@ MODULE mod_init
         INTEGER :: ii
 
         IF (griddir(2) == -1) THEN
-              DO ii = 1, 10
+              DO ii = 1, SIZE(jenn)
                 IF (isec == 2) THEN
                   jenn(ii) = jmt - jenn(ii)    ! Meridional reverse
                   jens(ii) = jmt - jens(ii)    ! Meridional reverse

--- a/src/mod_stream.F90
+++ b/src/mod_stream.F90
@@ -50,7 +50,7 @@ MODULE mod_stream
         IF (l_tracers) CALL open_outstream('yr')
         IF (l_tracers) CALL open_outstream('rr')
 
-        DO ilvar1 = 1, 21
+        DO ilvar1 = 1, maxlbas
 
             psi_xy(:,:) = 0.; psi_xz(:,:) = 0.; psi_yz(:,:) = 0.
             IF (l_tracers) THEN
@@ -170,7 +170,7 @@ MODULE mod_stream
 
           INTEGER :: index
 
-          index = 21
+          index = maxlbas
           IF (l_offline .EQV. .FALSE.) THEN
               index  = ntracmax
           END IF

--- a/src/mod_subdomain.F90
+++ b/src/mod_subdomain.F90
@@ -14,6 +14,8 @@ MODULE mod_subdomain
 
     USE mod_domain
     USE mod_grid
+    USE mod_tracervars
+    USE mod_postprocessvars
 
     IMPLICIT NONE
 
@@ -26,6 +28,15 @@ MODULE mod_subdomain
       ! Redifine the size of the domain if a subdomain is chosen.
       !
       ! --------------------------------------------------
+
+          INTEGER :: ntracerkill   ! number of tracer-based killing zones
+          INTEGER :: subgeomax     ! highest subdomain wall killing-zone slot
+          INTEGER :: ngeo          ! number of geographic killing-zone slots
+
+          subgeomax = 0
+          ! Subdomain wall killing zones occupy the LAST 4 geographic slots,
+          ! leaving the lower slots for user-defined namelist zones.
+          ngeo      = SIZE(ienw)
 
           ! Make sure killing zones are on
           IF (exitType==2 .AND. l_subdom) THEN
@@ -55,22 +66,25 @@ MODULE mod_subdomain
 
                   ! These killing zones will not be activated for hemispheric cap subdomains
                   IF ((iperio == 1 .AND. imt == imtdom .AND. jmaxdom == 1) .EQV. .FALSE.) THEN
-                    ! 7 - south wall
-                    ienw(7) = -1; iene(7) = imtdom + 1; jens(7) = jmindom + 1; jenn(7) = jmindom + 1
+                    ! south wall (4th-from-last slot)
+                    ienw(ngeo-3) = -1; iene(ngeo-3) = imtdom + 1; jens(ngeo-3) = jmindom + 1; jenn(ngeo-3) = jmindom + 1
+                    subgeomax = ngeo-3
                   END IF
 
                   IF ((iperio == 1 .AND. imt == imtdom .AND. jmaxdom == jmtdom) .EQV. .FALSE.) THEN
-                    ! 8 - north wall
-                    ienw(8) = -1; iene(8) = imtdom + 1; jens(8) = jmaxdom - 1; jenn(8) = jmaxdom - 1
+                    ! north wall (3rd-from-last slot)
+                    ienw(ngeo-2) = -1; iene(ngeo-2) = imtdom + 1; jens(ngeo-2) = jmaxdom - 1; jenn(ngeo-2) = jmaxdom - 1
+                    subgeomax = ngeo-2
                   END IF
 
                   ! These killing zones will not be activated if iperio = 1
                   ! and imindom = 1 and imaxdom = imt
                   IF ((iperio == 1 .AND. imt == imtdom) .EQV. .FALSE.) THEN
-                    ! 9 - east wall
-                    ienw(9) = imindom + 1; iene(9) = imindom + 1; jens(9) = -1; jenn(9) = jmtdom + 1
-                    ! 10 - west wall
-                    ienw(10) = imaxdom - 1; iene(10) = imaxdom - 1; jens(10) = - 1; jenn(10) = jmtdom + 1
+                    ! east wall (2nd-from-last slot)
+                    ienw(ngeo-1) = imindom + 1; iene(ngeo-1) = imindom + 1; jens(ngeo-1) = -1; jenn(ngeo-1) = jmtdom + 1
+                    ! west wall (last slot)
+                    ienw(ngeo) = imaxdom - 1; iene(ngeo) = imaxdom - 1; jens(ngeo) = - 1; jenn(ngeo) = jmtdom + 1
+                    subgeomax = ngeo
                   END IF
 
                   ! Redefine the killing zones in the new reference system
@@ -89,14 +103,15 @@ MODULE mod_subdomain
                   jmt = jmaxdom - jmindom + 1
 
                   ! The last 4 kill zones are reserved to the Subdomain
-                  ! 7 - south wall
-                  ienw(7) = -1; iene(7) = imt + 1; jens(7) = jmindom + 1; jenn(7) = jmindom + 1
-                  ! 8 - north wall
-                  ienw(8) = -1; iene(8) = imt + 1; jens(8) = jmaxdom - 1; jenn(8) = jmaxdom - 1
-                  ! 9 - east wall
-                  ienw(9) = imindom + 1; iene(9) = imindom + 1; jens(9) = -1; jenn(9) = jmt + 1
-                  ! 10 - west wall
-                  ienw(10) = imaxdom - 1; iene(10) = imaxdom - 1; jens(10) = - 1; jenn(10) = jmt + 1
+                  ! south wall (4th-from-last slot)
+                  ienw(ngeo-3) = -1; iene(ngeo-3) = imt + 1; jens(ngeo-3) = jmindom + 1; jenn(ngeo-3) = jmindom + 1
+                  ! north wall (3rd-from-last slot)
+                  ienw(ngeo-2) = -1; iene(ngeo-2) = imt + 1; jens(ngeo-2) = jmaxdom - 1; jenn(ngeo-2) = jmaxdom - 1
+                  ! east wall (2nd-from-last slot)
+                  ienw(ngeo-1) = imindom + 1; iene(ngeo-1) = imindom + 1; jens(ngeo-1) = -1; jenn(ngeo-1) = jmt + 1
+                  ! west wall (last slot)
+                  ienw(ngeo) = imaxdom - 1; iene(ngeo) = imaxdom - 1; jens(ngeo) = - 1; jenn(ngeo) = jmt + 1
+                  subgeomax = ngeo
 
                   ! Redefine the killing zones in the new reference system
                   ienw = ienw - imindom + 1; iene = iene - imindom + 1;
@@ -115,6 +130,38 @@ MODULE mod_subdomain
               ! If l_subdom is false the subdomain is the entire domain
               imindom =   1; jmindom =   1
 
+          END IF
+
+          ! Finalise maxlbas now that exitType (possibly promoted above) and all
+          ! killing zones are known. Size the per-zone streamfunction/summary
+          ! arrays to the actual run. nend (lbas) encoding in the project
+          ! kill_zones.F90 routines:
+          !   nend = 0               -> time limit
+          !   nend = 1               -> reaching the surface
+          !   nend = nexit+1         -> geographic killing zone nexit
+          !   nend = nexit+1+numexit -> tracer killing zone (exitType 3)
+          ! ngeozones (highest geographic slot) was seeded from the namelist in
+          ! init_namelist; bump it for the subdomain wall zones added above.
+          ! Tracer zones are counted via the 999 sentinel default.
+          ngeozones   = MAX(ngeozones, subgeomax)
+          ntracerkill = COUNT(tracerchoice /= 999)
+
+          SELECT CASE (exitType)
+          CASE (1)        ! geographic killing zones only
+              maxlbas = 1 + ngeozones
+          CASE (2)        ! tracer-based killing zones only
+              maxlbas = 1 + ntracerkill
+          CASE (3)        ! tracer + geographic killing zones
+              maxlbas = 1 + ntracerkill + ngeozones
+          CASE DEFAULT    ! exitType 4 (hard coded) or unset: full safety
+              maxlbas = MAXZONES
+          END SELECT
+
+          IF (maxlbas > MAXZONES) THEN
+              PRINT*, 'ERROR: number of killing zones (maxlbas =', maxlbas, &
+                      ') exceeds MAXZONES =', MAXZONES
+              PRINT*, 'Increase MAXZONES in mod_precdef (src/mod_vars.F90).'
+              STOP
           END IF
 
       END SUBROUTINE init_subdomain

--- a/src/mod_tracers.F90
+++ b/src/mod_tracers.F90
@@ -20,7 +20,7 @@ MODULE mod_tracers
 
     IMPLICIT NONE
 
-    INTEGER, DIMENSION(10) :: numtracerarray = 0
+    INTEGER, DIMENSION(MAXTRACERS) :: numtracerarray = 0
 
     PRIVATE :: tracers_default
 
@@ -39,7 +39,7 @@ MODULE mod_tracers
 
         ! Calculate the number of tracers
         WHERE (tracername==' ') numtracerarray = 1
-        numtracers = 10 - SUM(numtracerarray)
+        numtracers = SIZE(numtracerarray) - SUM(numtracerarray)
 
         ! Allocate the tracer array
         ALLOCATE(tracers(numtracers), tracervalue(numtracers))

--- a/src/mod_vars.F90
+++ b/src/mod_vars.F90
@@ -31,6 +31,15 @@ MODULE mod_precdef
    INTEGER, PARAMETER                       :: PP = selected_real_kind(6 ,  37)
    INTEGER, PARAMETER                       :: DP = selected_real_kind(15, 307)
    INTEGER, PARAMETER                       :: QP = selected_real_kind(33, 4931)
+
+   ! Maximum capacities for killing zones and tracers. These statically
+   ! dimension the configuration arrays; runtime loops should derive their
+   ! bounds from SIZE() of the array, and the actual number of streamfunction
+   ! zones used is the computed variable maxlbas.
+   INTEGER, PARAMETER                       :: MAXGEOZONES = 10   ! geographic killing-zone slots (ienw/iene/jens/jenn)
+   INTEGER, PARAMETER                       :: MAXTRACERS  = 10   ! tracer slots (tracerchoice, etc.)
+   ! Max killing zones (lbas): 1 (surface) + tracer killing zones + geographic.
+   INTEGER, PARAMETER                       :: MAXZONES    = 1 + MAXTRACERS + MAXGEOZONES
 ENDMODULE mod_precdef
 
 ! Verbose options
@@ -321,7 +330,8 @@ MODULE mod_domain
   LOGICAL                                 :: l_nosurface = .FALSE.  ! Can trajectories reach the surface?
 
   INTEGER                                 :: exitType
-  INTEGER, DIMENSION(10)                  :: ienw ,iene, jens ,jenn ! Horizontal killing zones
+  INTEGER, DIMENSION(MAXGEOZONES)         :: ienw = 0, iene = 0, jens = 0, jenn = 0 ! Horizontal killing zones
+  INTEGER                                 :: ngeozones = 0          ! Highest occupied geographic killing-zone slot
 
   REAL(PP)                                :: timax                  ! Maximum time to run a trajectory
 
@@ -374,15 +384,15 @@ MODULE mod_tracervars
   INTEGER                             :: numtracers = 0
 
   ! Tracer choice
-  INTEGER, DIMENSION(10)              :: tracerchoice = 999, maxormin = 1
+  INTEGER, DIMENSION(MAXTRACERS)      :: tracerchoice = 999, maxormin = 1
 
   ! Tracer characteristics
-  CHARACTER(len=100), DIMENSION(10)   :: tracername = '', tracerunit, &
+  CHARACTER(len=100), DIMENSION(MAXTRACERS) :: tracername = '', tracerunit, &
                                          tracervarname,traceraction
 
-  CHARACTER(len=2), DIMENSION(10)     :: tracerdimension = '3D'
+  CHARACTER(len=2), DIMENSION(MAXTRACERS) :: tracerdimension = '3D'
 
-  REAL(DP), DIMENSION(10)             :: tracermin, tracermax, &
+  REAL(DP), DIMENSION(MAXTRACERS)    :: tracermin, tracermax, &
                                          tracer0min=-9999.d0, tracer0max=9999.d0, &
                                          tracershift=0.d0, tracerscale=1.d0, &
                                          tracere
@@ -418,7 +428,7 @@ MODULE mod_psi
   INTEGER    :: xyflux = 1
 
   ! Direction integration
-  INTEGER , DIMENSION(21)   :: dirpsi = 1
+  INTEGER , DIMENSION(MAXZONES)   :: dirpsi = 1
 
   ! Barotropic streamfunction
   REAL(DP), ALLOCATABLE, DIMENSION(:,:,:) :: fluxes_xy
@@ -457,11 +467,11 @@ MODULE mod_postprocessvars
   INTEGER, DIMENSION(:),ALLOCATABLE       :: nsavewrite
   INTEGER                                 :: nsave = 0
 
-  INTEGER, DIMENSION(0:21)                :: ntrajout = 0
+  INTEGER, DIMENSION(0:MAXZONES)          :: ntrajout = 0
   INTEGER                                 :: ntrajtot = 0
-  INTEGER                                 :: maxlbas = 0
+  INTEGER                                 :: maxlbas = MAXZONES
 
-  REAL(DP), DIMENSION(0:21)               :: volout = 0
+  REAL(DP), DIMENSION(0:MAXZONES)         :: volout = 0
   REAL(DP)                                :: voltot = 0
 
   ! Temporary trajectory information
@@ -495,6 +505,6 @@ MODULE mod_divvars
   LOGICAL   :: l_divergence = .FALSE.
 
   REAL(DP), DIMENSION(:,:,:,:), ALLOCATABLE :: tracerdiv
-  REAL(DP), DIMENSION(10)                   :: divconst = 1.d0
+  REAL(DP), DIMENSION(MAXTRACERS)           :: divconst = 1.d0
 
 END MODULE mod_divvars

--- a/src/mod_write.F90
+++ b/src/mod_write.F90
@@ -456,7 +456,10 @@ MODULE mod_write
           REWIND (34)
 
           DO ll = 1, numline
-              READ (UNIT=34, fmt="(I8,I3,I10)") ntrac, lbas, nsavewrite(ntrac)
+              ! _rerun.csv is written comma-separated (see write_data); use
+              ! list-directed input so lbas is parsed correctly (a fixed
+              ! "(I8,I3,I10)" format misreads the comma-separated fields).
+              READ (UNIT=34, fmt=*) ntrac, lbas, nsavewrite(ntrac)
               trajectories(ntrac)%lbas = lbas
           END DO
 


### PR DESCRIPTION
## Summary

Two independent fixes to the `./runtracmass rerun` file-handling path. As-is, a rerun pass cannot re-read the trajectory labels (`lbas`) it needs, so it silently deactivates/mislabels every trajectory.

> ⚠️ **Stacked on #16.** The "Files changed" tab includes #16's commits until it merges — this PR's own change is the single commit *"Fix _rerun.csv file handling…"*. It will retarget cleanly to `main` once #16 lands.

## The bugs

1. **Filename prefix applied too late.** `outDataFile` defaults to `'TRACMASS'` only inside `open_outfiles`, which runs *after* `read_rerun`. So `read_rerun` looked for `_rerun.csv` instead of `TRACMASS_rerun.csv` → "No rerun file" → every trajectory label left unset. Fixed by applying the default in `init_namelist`, before first use.
2. **Read/write format mismatch.** `_rerun.csv` is written comma-separated (`(I8,',',I3,',',I10)`) but `read_rerun` parsed it with `(I8,I3,I10)`, mis-reading `lbas`. Fixed with list-directed input.

## Effect

Without these, a rerun pass reports `0 exited` and writes an empty `_run.csv` — it never re-integrates the labelled trajectories. (Offline never noticed because it ignores the re-integration and re-reads the trajectory files from disk.) With the fixes, a rerun pass correctly re-seeds and re-integrates the labelled trajectories — **verified: exit positions are identical to a normal run.**

## Also fixes a crash in offline rerun

As a side effect, this resolves a crash in **offline** rerun (`./runtracmass rerun` with `l_offline=.TRUE.`). On `main`, the broken file handling leaves every trajectory deactivated, producing inconsistent `_ini`/`_rerun` files; the offline postprocess then reads an `ntrac` beyond what it allocated and crashes:

```
Fortran runtime error: Index '442' of dimension 1 of array 'traj_out' above upper bound of 441
```

With `read_rerun` working, the files are consistent and the crash no longer occurs. (A separate, narrower robustness gap remains — the postprocess indexes `traj_out(ntrac1)` without a bounds check, so a genuinely inconsistent/stale `_rerun.csv` could still crash ungracefully — but that is independent of this PR.)

## Testing

Theoretical project, gfortran `-fbounds-check`: clean build; a rerun pass now reports the same terminations as the original run and reproduces identical trajectory exit positions; offline rerun completes without the out-of-bounds crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---
Addresses #19.
