### PR TITLE
Add memory-light online streamfunction mode (lbas-indexed)

### DIFF
--- a/projects/AVISO/kill_zones.F90
+++ b/projects/AVISO/kill_zones.F90
@@ -29,7 +29,7 @@ SUBROUTINE kill_zones
   ! Exit domain defined by the boxes [ienw, iene]x[jens, jenn]
   ! in the namelist
   CASE(1)
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1
@@ -66,7 +66,7 @@ SUBROUTINE kill_zones
       END DO
 
       ! Next the geographical killing zone
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1 + numexit

--- a/projects/IFS/kill_zones.F90
+++ b/projects/IFS/kill_zones.F90
@@ -29,7 +29,7 @@ SUBROUTINE kill_zones
   ! Exit domain defined by the boxes [ienw, iene]x[jens, jenn]
   ! in the namelist
   CASE(1)
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1
@@ -66,7 +66,7 @@ SUBROUTINE kill_zones
       END DO
 
       ! Next the geographical killing zone
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1 + numexit

--- a/projects/NEMO/kill_zones.F90
+++ b/projects/NEMO/kill_zones.F90
@@ -29,7 +29,7 @@ SUBROUTINE kill_zones
   ! Exit domain defined by the boxes [ienw, iene]x[jens, jenn]
   ! in the namelist
   CASE(1)
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1
@@ -66,7 +66,7 @@ SUBROUTINE kill_zones
       END DO
 
       ! Next the geographical killing zone
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1 + numexit

--- a/projects/ROMS/kill_zones.F90
+++ b/projects/ROMS/kill_zones.F90
@@ -29,7 +29,7 @@ SUBROUTINE kill_zones
   ! Exit domain defined by the boxes [ienw, iene]x[jens, jenn]
   ! in the namelist
   CASE(1)
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1
@@ -66,7 +66,7 @@ SUBROUTINE kill_zones
       END DO
 
       ! Next the geographical killing zone
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1 + numexit

--- a/projects/Theoretical/kill_zones.F90
+++ b/projects/Theoretical/kill_zones.F90
@@ -29,7 +29,7 @@ SUBROUTINE kill_zones
   ! Exit domain defined by the boxes [ienw, iene]x[jens, jenn]
   ! in the namelist
   CASE(1)
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1
@@ -66,7 +66,7 @@ SUBROUTINE kill_zones
       END DO
 
       ! Next the geographical killing zone
-      DO nexit = 1, 10
+      DO nexit = 1, SIZE(ienw)
          IF(ienw(nexit) <= x1 .AND. x1 <= iene(nexit) .AND. &
               jens(nexit) <= y1 .AND. y1 <= jenn(nexit) ) THEN
               nend = nexit +1 + numexit

--- a/src/mod_diffusion.F90
+++ b/src/mod_diffusion.F90
@@ -191,7 +191,7 @@ MODULE mod_diffusion
         REAL(DP), INTENT(INOUT) :: xb, xa, yb, ya
         INTEGER :: nexit
 
-        DO nexit = 1, 10
+        DO nexit = 1, SIZE(ienw)
 
             ! Latitude band
             IF (jens(nexit) == jenn(nexit)) THEN

--- a/src/mod_init.F90
+++ b/src/mod_init.F90
@@ -94,6 +94,11 @@ MODULE mod_init
           READ (8,nml=INIT_ACTIVE)
           CLOSE(8)
 
+          ! Default the output-file prefix here, before it is first used.
+          ! read_rerun runs before open_outfiles, so applying the default only
+          ! inside open_outfiles left read_rerun looking for the wrong filename.
+          IF (TRIM(outDataFile) == '') outDataFile = 'TRACMASS'
+
           ! Detect the highest occupied geographic killing-zone slot from the
           ! namelist, before reverse()/zeroindx mutate the arrays below. Boxes
           ! live in up to 10 slots [ienw,iene]x[jens,jenn]; kill_zones sets

--- a/src/mod_init.F90
+++ b/src/mod_init.F90
@@ -69,7 +69,7 @@ MODULE mod_init
           namelist /INIT_TRACERS_SEEDING/  tracer0min, tracer0max
           namelist /INIT_KILLZONES/        timax, l_nosurface, exitType, ienw, iene, jens, jenn, &
                                            tracerchoice, tracere, maxormin
-          namelist /INIT_POSTPROCESS/      l_psi, l_offline, dirpsi, xyflux, &
+          namelist /INIT_POSTPROCESS/      l_psi, l_offline, l_psi_rerun, dirpsi, xyflux, &
                                            l_divergence, divconst
           namelist /INIT_ACTIVE/           l_diffusion, ah, av
 

--- a/src/mod_init.F90
+++ b/src/mod_init.F90
@@ -73,6 +73,9 @@ MODULE mod_init
                                            l_divergence, divconst
           namelist /INIT_ACTIVE/           l_diffusion, ah, av
 
+          ! Loop index for scanning geographic killing-zone slots
+          INTEGER :: izone
+
           ! Read namelist
           OPEN (8,file='namelist.in',    &
                & status='OLD', delim='APOSTROPHE')
@@ -90,6 +93,19 @@ MODULE mod_init
           READ (8,nml=INIT_POSTPROCESS)
           READ (8,nml=INIT_ACTIVE)
           CLOSE(8)
+
+          ! Detect the highest occupied geographic killing-zone slot from the
+          ! namelist, before reverse()/zeroindx mutate the arrays below. Boxes
+          ! live in up to 10 slots [ienw,iene]x[jens,jenn]; kill_zones sets
+          ! nend = slot+1, so the slot INDEX (not the count) sets the largest
+          ! geographic lbas. Undefined slots are all-zero (initialised in
+          ! mod_vars). Subdomain wall zones and the final maxlbas are added in
+          ! init_subdomain, once exitType and all killing zones are finalised.
+          ngeozones = 0
+          DO izone = 1, SIZE(ienw)
+              IF (ienw(izone) /= 0 .OR. iene(izone) /= 0 .OR. &
+                  jens(izone) /= 0 .OR. jenn(izone) /= 0) ngeozones = izone
+          END DO
 
           ! If input data is on a A grid
 #ifdef A_grid
@@ -174,7 +190,7 @@ MODULE mod_init
         INTEGER :: ii
 
         IF (griddir(2) == -1) THEN
-              DO ii = 1, 10
+              DO ii = 1, SIZE(jenn)
                 IF (isec == 2) THEN
                   jenn(ii) = jmt - jenn(ii)    ! Meridional reverse
                   jens(ii) = jmt - jens(ii)    ! Meridional reverse

--- a/src/mod_stream.F90
+++ b/src/mod_stream.F90
@@ -59,8 +59,10 @@ MODULE mod_stream
                psi_rr(:,:)   = 0.
             END IF
 
-            ! For online calculation - adding fluxes
-            IF (l_offline .EQV. .FALSE.) THEN
+            ! Legacy per-trajectory online calculation: sum each trajectory's
+            ! fluxes into slot 0 by killing zone. Offline and the lbas-indexed
+            ! rerun mode already have fluxes binned by zone, so they skip this.
+            IF ((l_offline .EQV. .FALSE.) .AND. (l_psi_rerun .EQV. .FALSE.)) THEN
 
               ! Cleaning of fluxes
               fluxes_xy(:,:,0) = 0.d0;   fluxes_xz(:,:,0) = 0.d0;   fluxes_yz(:,:,0) = 0.d0
@@ -94,8 +96,10 @@ MODULE mod_stream
               END DO intrajLoop
             END IF
 
+            ! Pre-binned fluxes (offline / rerun) read zone ilvar1 directly;
+            ! legacy online reads the summed slot 0.
             ilvar3 = 0
-            IF (l_offline) ilvar3 = ilvar1
+            IF (l_offline .OR. l_psi_rerun) ilvar3 = ilvar1
 
             IF (dirpsi(ilvar1) == 1) THEN
                 DO ilvar2 = 2, MAX(imtdom,jmtdom,km,resolution)
@@ -170,8 +174,11 @@ MODULE mod_stream
 
           INTEGER :: index
 
+          ! Legacy per-trajectory online accumulation needs one slot per
+          ! trajectory (lbas unknown during the run); offline and the
+          ! lbas-indexed rerun mode size to the killing-zone count maxlbas.
           index = maxlbas
-          IF (l_offline .EQV. .FALSE.) THEN
+          IF ((l_offline .EQV. .FALSE.) .AND. (l_psi_rerun .EQV. .FALSE.)) THEN
               index  = ntracmax
           END IF
 
@@ -208,8 +215,18 @@ MODULE mod_stream
         INTEGER, INTENT(IN)           :: indx1, indx2, dir
         INTEGER, INTENT(IN), OPTIONAL :: indt1, indt2
         CHARACTER(LEN=2), INTENT(IN)  :: psicase
-        INTEGER                       :: index1, index2, indm1, indm2
+        INTEGER                       :: index1, index2, indm1, indm2, ipsi
         REAL(DP)                      :: slope
+
+        ! Select the flux-array slot. Legacy online accumulation stores one
+        ! slot per trajectory (lbas not yet known); the lbas-indexed rerun
+        ! mode stores directly into the trajectory's killing-zone slot.
+        IF (l_psi_rerun) THEN
+            ipsi = trajectories(ntrac)%lbas
+            IF (ipsi <= 0) RETURN
+        ELSE
+            ipsi = ntrac
+        END IF
 
         !
         index1 = indx1
@@ -230,15 +247,15 @@ MODULE mod_stream
         END IF
 
         ! Geographical streamfunctions
-        IF (psicase=='xy') fluxes_xy(index1,index2,ntrac) = fluxes_xy(index1,index2,ntrac) + dir*subvol
-        IF (psicase=='xz') fluxes_xz(index1,index2,ntrac) = fluxes_xz(index1,index2,ntrac) + dir*subvol
-        IF (psicase=='yz') fluxes_yz(index1,index2,ntrac) = fluxes_yz(index1,index2,ntrac) + dir*subvol
+        IF (psicase=='xy') fluxes_xy(index1,index2,ipsi) = fluxes_xy(index1,index2,ipsi) + dir*subvol
+        IF (psicase=='xz') fluxes_xz(index1,index2,ipsi) = fluxes_xz(index1,index2,ipsi) + dir*subvol
+        IF (psicase=='yz') fluxes_yz(index1,index2,ipsi) = fluxes_yz(index1,index2,ipsi) + dir*subvol
 
         ! Geographical + tracer
         IF (psicase=='xr' .AND. PRESENT(indt1)) THEN
-           fluxes_xr(index1,index2,ntrac,indt1) = fluxes_xr(index1,index2,ntrac,indt1) + dir*subvol
+           fluxes_xr(index1,index2,ipsi,indt1) = fluxes_xr(index1,index2,ipsi,indt1) + dir*subvol
         ELSE IF (psicase=='yr' .AND. PRESENT(indt1)) THEN
-           fluxes_yr(index1,index2,ntrac,indt1) = fluxes_yr(index1,index2,ntrac,indt1) + dir*subvol
+           fluxes_yr(index1,index2,ipsi,indt1) = fluxes_yr(index1,index2,ipsi,indt1) + dir*subvol
         END IF
 
         ! Tracer-tracer equation
@@ -249,7 +266,7 @@ MODULE mod_stream
               slope  = (FLOAT(indm1)-FLOAT(index1))*(FLOAT(indt2)-FLOAT(indt1))/(FLOAT(index2)-FLOAT(index1))
               indm2 = NINT( slope + indt1)
 
-              fluxes_rr(indm1,indm2,ntrac) = fluxes_rr(indm1,indm2,ntrac) + subvol
+              fluxes_rr(indm1,indm2,ipsi) = fluxes_rr(indm1,indm2,ipsi) + subvol
           END DO
 
           DO indm1 = index2, index1-1
@@ -257,7 +274,7 @@ MODULE mod_stream
               slope  = (FLOAT(indm1)-FLOAT(index1))*(FLOAT(indt2)-FLOAT(indt1))/(FLOAT(index2)-FLOAT(index1))
               indm2 = NINT( slope + indt1)
 
-              fluxes_rr(indm1,indm2,ntrac) = fluxes_rr(indm1,indm2,ntrac) - subvol
+              fluxes_rr(indm1,indm2,ipsi) = fluxes_rr(indm1,indm2,ipsi) - subvol
           END DO
 
         END IF

--- a/src/mod_stream.F90
+++ b/src/mod_stream.F90
@@ -50,7 +50,7 @@ MODULE mod_stream
         IF (l_tracers) CALL open_outstream('yr')
         IF (l_tracers) CALL open_outstream('rr')
 
-        DO ilvar1 = 1, 21
+        DO ilvar1 = 1, maxlbas
 
             psi_xy(:,:) = 0.; psi_xz(:,:) = 0.; psi_yz(:,:) = 0.
             IF (l_tracers) THEN
@@ -170,7 +170,7 @@ MODULE mod_stream
 
           INTEGER :: index
 
-          index = 21
+          index = maxlbas
           IF (l_offline .EQV. .FALSE.) THEN
               index  = ntracmax
           END IF

--- a/src/mod_subdomain.F90
+++ b/src/mod_subdomain.F90
@@ -14,6 +14,8 @@ MODULE mod_subdomain
 
     USE mod_domain
     USE mod_grid
+    USE mod_tracervars
+    USE mod_postprocessvars
 
     IMPLICIT NONE
 
@@ -26,6 +28,15 @@ MODULE mod_subdomain
       ! Redifine the size of the domain if a subdomain is chosen.
       !
       ! --------------------------------------------------
+
+          INTEGER :: ntracerkill   ! number of tracer-based killing zones
+          INTEGER :: subgeomax     ! highest subdomain wall killing-zone slot
+          INTEGER :: ngeo          ! number of geographic killing-zone slots
+
+          subgeomax = 0
+          ! Subdomain wall killing zones occupy the LAST 4 geographic slots,
+          ! leaving the lower slots for user-defined namelist zones.
+          ngeo      = SIZE(ienw)
 
           ! Make sure killing zones are on
           IF (exitType==2 .AND. l_subdom) THEN
@@ -55,22 +66,25 @@ MODULE mod_subdomain
 
                   ! These killing zones will not be activated for hemispheric cap subdomains
                   IF ((iperio == 1 .AND. imt == imtdom .AND. jmaxdom == 1) .EQV. .FALSE.) THEN
-                    ! 7 - south wall
-                    ienw(7) = -1; iene(7) = imtdom + 1; jens(7) = jmindom + 1; jenn(7) = jmindom + 1
+                    ! south wall (4th-from-last slot)
+                    ienw(ngeo-3) = -1; iene(ngeo-3) = imtdom + 1; jens(ngeo-3) = jmindom + 1; jenn(ngeo-3) = jmindom + 1
+                    subgeomax = ngeo-3
                   END IF
 
                   IF ((iperio == 1 .AND. imt == imtdom .AND. jmaxdom == jmtdom) .EQV. .FALSE.) THEN
-                    ! 8 - north wall
-                    ienw(8) = -1; iene(8) = imtdom + 1; jens(8) = jmaxdom - 1; jenn(8) = jmaxdom - 1
+                    ! north wall (3rd-from-last slot)
+                    ienw(ngeo-2) = -1; iene(ngeo-2) = imtdom + 1; jens(ngeo-2) = jmaxdom - 1; jenn(ngeo-2) = jmaxdom - 1
+                    subgeomax = ngeo-2
                   END IF
 
                   ! These killing zones will not be activated if iperio = 1
                   ! and imindom = 1 and imaxdom = imt
                   IF ((iperio == 1 .AND. imt == imtdom) .EQV. .FALSE.) THEN
-                    ! 9 - east wall
-                    ienw(9) = imindom + 1; iene(9) = imindom + 1; jens(9) = -1; jenn(9) = jmtdom + 1
-                    ! 10 - west wall
-                    ienw(10) = imaxdom - 1; iene(10) = imaxdom - 1; jens(10) = - 1; jenn(10) = jmtdom + 1
+                    ! east wall (2nd-from-last slot)
+                    ienw(ngeo-1) = imindom + 1; iene(ngeo-1) = imindom + 1; jens(ngeo-1) = -1; jenn(ngeo-1) = jmtdom + 1
+                    ! west wall (last slot)
+                    ienw(ngeo) = imaxdom - 1; iene(ngeo) = imaxdom - 1; jens(ngeo) = - 1; jenn(ngeo) = jmtdom + 1
+                    subgeomax = ngeo
                   END IF
 
                   ! Redefine the killing zones in the new reference system
@@ -89,14 +103,15 @@ MODULE mod_subdomain
                   jmt = jmaxdom - jmindom + 1
 
                   ! The last 4 kill zones are reserved to the Subdomain
-                  ! 7 - south wall
-                  ienw(7) = -1; iene(7) = imt + 1; jens(7) = jmindom + 1; jenn(7) = jmindom + 1
-                  ! 8 - north wall
-                  ienw(8) = -1; iene(8) = imt + 1; jens(8) = jmaxdom - 1; jenn(8) = jmaxdom - 1
-                  ! 9 - east wall
-                  ienw(9) = imindom + 1; iene(9) = imindom + 1; jens(9) = -1; jenn(9) = jmt + 1
-                  ! 10 - west wall
-                  ienw(10) = imaxdom - 1; iene(10) = imaxdom - 1; jens(10) = - 1; jenn(10) = jmt + 1
+                  ! south wall (4th-from-last slot)
+                  ienw(ngeo-3) = -1; iene(ngeo-3) = imt + 1; jens(ngeo-3) = jmindom + 1; jenn(ngeo-3) = jmindom + 1
+                  ! north wall (3rd-from-last slot)
+                  ienw(ngeo-2) = -1; iene(ngeo-2) = imt + 1; jens(ngeo-2) = jmaxdom - 1; jenn(ngeo-2) = jmaxdom - 1
+                  ! east wall (2nd-from-last slot)
+                  ienw(ngeo-1) = imindom + 1; iene(ngeo-1) = imindom + 1; jens(ngeo-1) = -1; jenn(ngeo-1) = jmt + 1
+                  ! west wall (last slot)
+                  ienw(ngeo) = imaxdom - 1; iene(ngeo) = imaxdom - 1; jens(ngeo) = - 1; jenn(ngeo) = jmt + 1
+                  subgeomax = ngeo
 
                   ! Redefine the killing zones in the new reference system
                   ienw = ienw - imindom + 1; iene = iene - imindom + 1;
@@ -115,6 +130,38 @@ MODULE mod_subdomain
               ! If l_subdom is false the subdomain is the entire domain
               imindom =   1; jmindom =   1
 
+          END IF
+
+          ! Finalise maxlbas now that exitType (possibly promoted above) and all
+          ! killing zones are known. Size the per-zone streamfunction/summary
+          ! arrays to the actual run. nend (lbas) encoding in the project
+          ! kill_zones.F90 routines:
+          !   nend = 0               -> time limit
+          !   nend = 1               -> reaching the surface
+          !   nend = nexit+1         -> geographic killing zone nexit
+          !   nend = nexit+1+numexit -> tracer killing zone (exitType 3)
+          ! ngeozones (highest geographic slot) was seeded from the namelist in
+          ! init_namelist; bump it for the subdomain wall zones added above.
+          ! Tracer zones are counted via the 999 sentinel default.
+          ngeozones   = MAX(ngeozones, subgeomax)
+          ntracerkill = COUNT(tracerchoice /= 999)
+
+          SELECT CASE (exitType)
+          CASE (1)        ! geographic killing zones only
+              maxlbas = 1 + ngeozones
+          CASE (2)        ! tracer-based killing zones only
+              maxlbas = 1 + ntracerkill
+          CASE (3)        ! tracer + geographic killing zones
+              maxlbas = 1 + ntracerkill + ngeozones
+          CASE DEFAULT    ! exitType 4 (hard coded) or unset: full safety
+              maxlbas = MAXZONES
+          END SELECT
+
+          IF (maxlbas > MAXZONES) THEN
+              PRINT*, 'ERROR: number of killing zones (maxlbas =', maxlbas, &
+                      ') exceeds MAXZONES =', MAXZONES
+              PRINT*, 'Increase MAXZONES in mod_precdef (src/mod_vars.F90).'
+              STOP
           END IF
 
       END SUBROUTINE init_subdomain

--- a/src/mod_tracers.F90
+++ b/src/mod_tracers.F90
@@ -20,7 +20,7 @@ MODULE mod_tracers
 
     IMPLICIT NONE
 
-    INTEGER, DIMENSION(10) :: numtracerarray = 0
+    INTEGER, DIMENSION(MAXTRACERS) :: numtracerarray = 0
 
     PRIVATE :: tracers_default
 
@@ -39,7 +39,7 @@ MODULE mod_tracers
 
         ! Calculate the number of tracers
         WHERE (tracername==' ') numtracerarray = 1
-        numtracers = 10 - SUM(numtracerarray)
+        numtracers = SIZE(numtracerarray) - SUM(numtracerarray)
 
         ! Allocate the tracer array
         ALLOCATE(tracers(numtracers), tracervalue(numtracers))

--- a/src/mod_vars.F90
+++ b/src/mod_vars.F90
@@ -31,6 +31,15 @@ MODULE mod_precdef
    INTEGER, PARAMETER                       :: PP = selected_real_kind(6 ,  37)
    INTEGER, PARAMETER                       :: DP = selected_real_kind(15, 307)
    INTEGER, PARAMETER                       :: QP = selected_real_kind(33, 4931)
+
+   ! Maximum capacities for killing zones and tracers. These statically
+   ! dimension the configuration arrays; runtime loops should derive their
+   ! bounds from SIZE() of the array, and the actual number of streamfunction
+   ! zones used is the computed variable maxlbas.
+   INTEGER, PARAMETER                       :: MAXGEOZONES = 10   ! geographic killing-zone slots (ienw/iene/jens/jenn)
+   INTEGER, PARAMETER                       :: MAXTRACERS  = 10   ! tracer slots (tracerchoice, etc.)
+   ! Max killing zones (lbas): 1 (surface) + tracer killing zones + geographic.
+   INTEGER, PARAMETER                       :: MAXZONES    = 1 + MAXTRACERS + MAXGEOZONES
 ENDMODULE mod_precdef
 
 ! Verbose options
@@ -321,7 +330,8 @@ MODULE mod_domain
   LOGICAL                                 :: l_nosurface = .FALSE.  ! Can trajectories reach the surface?
 
   INTEGER                                 :: exitType
-  INTEGER, DIMENSION(10)                  :: ienw ,iene, jens ,jenn ! Horizontal killing zones
+  INTEGER, DIMENSION(MAXGEOZONES)         :: ienw = 0, iene = 0, jens = 0, jenn = 0 ! Horizontal killing zones
+  INTEGER                                 :: ngeozones = 0          ! Highest occupied geographic killing-zone slot
 
   REAL(PP)                                :: timax                  ! Maximum time to run a trajectory
 
@@ -374,15 +384,15 @@ MODULE mod_tracervars
   INTEGER                             :: numtracers = 0
 
   ! Tracer choice
-  INTEGER, DIMENSION(10)              :: tracerchoice = 999, maxormin = 1
+  INTEGER, DIMENSION(MAXTRACERS)      :: tracerchoice = 999, maxormin = 1
 
   ! Tracer characteristics
-  CHARACTER(len=100), DIMENSION(10)   :: tracername = '', tracerunit, &
+  CHARACTER(len=100), DIMENSION(MAXTRACERS) :: tracername = '', tracerunit, &
                                          tracervarname,traceraction
 
-  CHARACTER(len=2), DIMENSION(10)     :: tracerdimension = '3D'
+  CHARACTER(len=2), DIMENSION(MAXTRACERS) :: tracerdimension = '3D'
 
-  REAL(DP), DIMENSION(10)             :: tracermin, tracermax, &
+  REAL(DP), DIMENSION(MAXTRACERS)    :: tracermin, tracermax, &
                                          tracer0min=-9999.d0, tracer0max=9999.d0, &
                                          tracershift=0.d0, tracerscale=1.d0, &
                                          tracere
@@ -418,7 +428,7 @@ MODULE mod_psi
   INTEGER    :: xyflux = 1
 
   ! Direction integration
-  INTEGER , DIMENSION(21)   :: dirpsi = 1
+  INTEGER , DIMENSION(MAXZONES)   :: dirpsi = 1
 
   ! Barotropic streamfunction
   REAL(DP), ALLOCATABLE, DIMENSION(:,:,:) :: fluxes_xy
@@ -457,11 +467,11 @@ MODULE mod_postprocessvars
   INTEGER, DIMENSION(:),ALLOCATABLE       :: nsavewrite
   INTEGER                                 :: nsave = 0
 
-  INTEGER, DIMENSION(0:21)                :: ntrajout = 0
+  INTEGER, DIMENSION(0:MAXZONES)          :: ntrajout = 0
   INTEGER                                 :: ntrajtot = 0
-  INTEGER                                 :: maxlbas = 0
+  INTEGER                                 :: maxlbas = MAXZONES
 
-  REAL(DP), DIMENSION(0:21)               :: volout = 0
+  REAL(DP), DIMENSION(0:MAXZONES)         :: volout = 0
   REAL(DP)                                :: voltot = 0
 
   ! Temporary trajectory information
@@ -495,6 +505,6 @@ MODULE mod_divvars
   LOGICAL   :: l_divergence = .FALSE.
 
   REAL(DP), DIMENSION(:,:,:,:), ALLOCATABLE :: tracerdiv
-  REAL(DP), DIMENSION(10)                   :: divconst = 1.d0
+  REAL(DP), DIMENSION(MAXTRACERS)           :: divconst = 1.d0
 
 END MODULE mod_divvars

--- a/src/mod_vars.F90
+++ b/src/mod_vars.F90
@@ -423,6 +423,9 @@ MODULE mod_psi
   ! Streamfunctions on/off
   LOGICAL    :: l_psi     = .FALSE.
   LOGICAL    :: l_offline = .TRUE.
+  ! Memory-light online accumulation: index fluxes by killing zone (lbas)
+  ! instead of by trajectory. Requires a rerun pass so lbas is known up front.
+  LOGICAL    :: l_psi_rerun = .FALSE.
 
   ! Barotropic u(1)/v(2)
   INTEGER    :: xyflux = 1

--- a/src/mod_write.F90
+++ b/src/mod_write.F90
@@ -456,7 +456,10 @@ MODULE mod_write
           REWIND (34)
 
           DO ll = 1, numline
-              READ (UNIT=34, fmt="(I8,I3,I10)") ntrac, lbas, nsavewrite(ntrac)
+              ! _rerun.csv is written comma-separated (see write_data); use
+              ! list-directed input so lbas is parsed correctly (a fixed
+              ! "(I8,I3,I10)" format misreads the comma-separated fields).
+              READ (UNIT=34, fmt=*) ntrac, lbas, nsavewrite(ntrac)
               trajectories(ntrac)%lbas = lbas
           END DO
 


### PR DESCRIPTION
## Summary

Adds a memory-light **online** streamfunction mode that indexes fluxes by killing zone (`lbas`) instead of by trajectory, sizing the flux arrays `0:maxlbas` (~tens) instead of `0:ntracmax` (millions). This removes the per-trajectory memory that causes out-of-memory failures when computing streamfunctions online for runs with millions of particles.

> ⚠️ **Stacked on #17 → #16.** The "Files changed" tab includes those ancestors until they merge — this PR's own change is the single commit *"Add memory-light online streamfunction mode…"*.

## How it works

`lbas` is only known once a trajectory terminates, so the new mode runs as a **second pass**:
1. **Pass 1** — a normal run produces `_rerun.csv` with the `(ntrac, lbas)` labels.
2. **Pass 2** — `./runtracmass rerun` with `l_psi=.TRUE.`, `l_offline=.FALSE.`, `l_psi_rerun=.TRUE.` loads the labels (via `read_rerun`) and accumulates fluxes live, binned by `lbas`.

## Changes

- New namelist flag `l_psi_rerun` (`INIT_POSTPROCESS`), default `.FALSE.` — **additive**; legacy per-trajectory online accumulation is unchanged.
- `init_stream` sizes the flux arrays `0:maxlbas` in the new mode (legacy online still uses `0:ntracmax`).
- `update_fluxes` indexes the flux slot by the trajectory's `lbas`.
- `compute_stream` skips the per-trajectory summation in the new mode; the new path reuses the offline per-zone integration.

## Correctness

The new mode and legacy online both write `fluxes(:,:,lbas)` and integrate per zone, so they should produce identical streamfunctions. Verified **byte-identical** to legacy per-trajectory online on single- and multi-killzone configurations (and differs from offline only by the pre-existing online-vs-offline one-cell shift).

## Depends on

- **#16** — provides `maxlbas` (the per-zone array size).
- **#17** — the rerun pass must re-read its labels for pass 2 to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---
Addresses #19.
